### PR TITLE
Fix duplicate reorder logic in ManMirror

### DIFF
--- a/api/libs/man_mirror/__init__.py
+++ b/api/libs/man_mirror/__init__.py
@@ -256,15 +256,10 @@ class ManMirror:
                 if image_json.must_debug:
                     old_image_file = Image.fromarray(image)
                     old_image_file.save(f'{main_dir}/{page}-debug.png')
-                else:
-                    new_image, has_some_order_error = self.__re_order_images(
-                        image, image_json)
-                    if has_some_order_error:
-                        has_some_error = has_some_order_error
-                        old_image_file = Image.fromarray(image)
-                        old_image_file.save(f'{main_dir}/{page}-before-order.png')
+
                 new_image, has_some_order_error = self.__re_order_images(
                     image, image_json)
+
                 if has_some_order_error:
                     has_some_error = has_some_order_error
                     old_image_file = Image.fromarray(image)


### PR DESCRIPTION
## Summary
- avoid calling `__re_order_images` twice in `_download_cartoon_chapter_page`

## Testing
- `python -m py_compile api/libs/man_mirror/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6846a99e520883218a9ab99a7470df60