### PR TITLE
Use super() in NumpyArrayEncoder

### DIFF
--- a/api/libs/utils/numpy_array_encoder.py
+++ b/api/libs/utils/numpy_array_encoder.py
@@ -9,4 +9,4 @@ class NumpyArrayEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, np.ndarray):
             return o.tolist()
-        return json.JSONEncoder.default(self, o)
+        return super().default(o)


### PR DESCRIPTION
## Summary
- simplify `NumpyArrayEncoder.default` by using `super().default`

## Testing
- `python -m py_compile api/libs/utils/numpy_array_encoder.py`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846aa7e09dc8321922026ff39c11198